### PR TITLE
Adding README.md for the sct_dbtool folder

### DIFF
--- a/sct_dbtool/README.md
+++ b/sct_dbtool/README.md
@@ -1,0 +1,5 @@
+## SCT DB Tool
+This folder contains the `sct_dbtool` command-line tool used
+to check the MRI database sanity.
+
+Read the [documentation](https://sct-dbtool.readthedocs.io) for how to install and use.


### PR DESCRIPTION
I forgot to add a README.md to the `sct_dbtool` folder with the link to the documentation.