### PR TITLE
Fix acquisition display name to contain underscore

### DIFF
--- a/sct_annotation/annotations/models.py
+++ b/sct_annotation/annotations/models.py
@@ -70,7 +70,7 @@ class Acquisition(models.Model):
     session = models.CharField(max_length=64)
 
     def __str__(self):
-        return f'{self.center} {self.study} {self.session}'
+        return f'{self.center}_{self.study}_{self.session}'
 
     class Meta:
         unique_together = (('center', 'study', 'session'))


### PR DESCRIPTION
The acquisition model was modified to return `center_study_session` when the model is called instead of `center study session`

Fixes #54 